### PR TITLE
printing hex values instead of decimals for raw modbus logging

### DIFF
--- a/rtuclient.go
+++ b/rtuclient.go
@@ -114,7 +114,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 		defer mb.Close()
 	}
 	if mb.Logger != nil {
-		mb.Logger.Printf("modbus: sending %v\n", aduRequest)
+		mb.Logger.Printf("modbus: sending %#v\n", aduRequest)
 	}
 	var n int
 	if n, err = mb.write(aduRequest); err != nil {
@@ -126,7 +126,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	}
 	aduResponse = data[:n]
 	if mb.Logger != nil {
-		mb.Logger.Printf("modbus: received %v\n", aduResponse)
+		mb.Logger.Printf("modbus: received %#v\n", aduResponse)
 	}
 	return
 }

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -118,7 +118,7 @@ func (mb *serialTransporter) read(b []byte) (n int, err error) {
 	fdSet(fd, &rfds)
 
 	timeout := syscall.NsecToTimeval(mb.Timeout.Nanoseconds())
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(40 * time.Millisecond)
 	if _, err = syscall.Select(fd+1, &rfds, nil, nil, &timeout); err != nil {
 		return
 	}

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -118,7 +118,7 @@ func (mb *serialTransporter) read(b []byte) (n int, err error) {
 	fdSet(fd, &rfds)
 
 	timeout := syscall.NsecToTimeval(mb.Timeout.Nanoseconds())
-
+	time.Sleep(300 * time.Millisecond)
 	if _, err = syscall.Select(fd+1, &rfds, nil, nil, &timeout); err != nil {
 		return
 	}


### PR DESCRIPTION
I'm using your library to create an interface for an Eastron SDM630-Modbus electricity meter. During development I find it easier to look at hexadecimal dumps of the data packets - which is what I implemented here.