### PR TITLE
When the RTU package contains an error code, the module recognizes it…

### DIFF
--- a/rtuclient.go
+++ b/rtuclient.go
@@ -130,8 +130,8 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	var n int
 	var n1 int
 	var data [rtuMaxSize]byte
-	//the minimum length should be 5. As the error package is 5 bytes long
-	//
+	//We first read the minimum length and then read either the full package
+	//or the error package, depending on the error status (byte 2 of the response)
 	n, err = io.ReadAtLeast(mb.port, data[:], rtuMinSize)
 	if err != nil {
 		return

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -122,16 +122,39 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	if _, err = mb.port.Write(aduRequest); err != nil {
 		return
 	}
+	function := aduRequest[1]
+	functionFail := aduRequest[1] & 0x80
 	bytesToRead := calculateResponseLength(aduRequest)
 	time.Sleep(mb.calculateDelay(len(aduRequest) + bytesToRead))
 
 	var n int
+	var n1 int
 	var data [rtuMaxSize]byte
-	if bytesToRead > rtuMinSize && bytesToRead <= rtuMaxSize {
-		n, err = io.ReadFull(mb.port, data[:bytesToRead])
-	} else {
-		n, err = io.ReadAtLeast(mb.port, data[:], rtuMinSize)
+	//the minimum length should be 5. As the error package is 5 bytes long
+	//
+	n, err = io.ReadAtLeast(mb.port, data[:], rtuMinSize)
+	if err != nil {
+		return
 	}
+	//if the function is correct
+	if data[1] == function {
+		//we read the rest of the bytes
+		if n < bytesToRead {
+			if bytesToRead > rtuMinSize && bytesToRead <= rtuMaxSize {
+				if bytesToRead > n {
+					n1, err = io.ReadFull(mb.port, data[n:bytesToRead])
+					n += n1
+				}
+			}
+		}
+	} else if data[1] == functionFail {
+		//for error we need to read 5 bytes
+		if n < bytesToRead {
+			n1, err = io.ReadFull(mb.port, data[n:5])
+		}
+		n += n1
+	}
+
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
…. There is no more waiting until the timeout is reached in case of error package from slave.
Until now, of a slave would respond with an error code, the master would wait until timeout and then analyse the package.
This fix looks for the error code as soon as at least 4 characters arrive (the min package length) and if an error code is seen in the package it waits for the full error response package (another 1 byte) if not already arrived and then transmits the package.
This fixes the timeout issue because before you would need to wait for the correct response package length before timeout and that is often 6 bytes or more (as opposed to 5 bytes for error)/

