### PR TITLE
switch around meaning of high and low byte of crc as per implementation guide

### DIFF
--- a/crc.go
+++ b/crc.go
@@ -60,9 +60,9 @@ func (crc *crc) pushBytes(bs []byte) *crc {
 	var idx, b byte
 
 	for _, b = range bs {
-		idx = crc.high ^ b
-		crc.high = crc.low ^ crcHighBytes[idx]
-		crc.low = crcLowBytes[idx]
+		idx = crc.low ^ b
+		crc.low = crc.high ^ crcHighBytes[idx]
+		crc.high = crcLowBytes[idx]
 	}
 	return crc
 }

--- a/crc_test.go
+++ b/crc_test.go
@@ -13,7 +13,7 @@ func TestCRC(t *testing.T) {
 	crc.reset()
 	crc.pushBytes([]byte{0x02, 0x07})
 
-	if 0x4112 != crc.value() {
-		t.Fatalf("crc expected %v, actual %v", 0x4112, crc.value())
+	if 0x1241 != crc.value() {
+		t.Fatalf("crc expected %v, actual %v", 0x1241, crc.value())
 	}
 }

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -63,8 +63,8 @@ func (mb *rtuPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	crc.reset().pushBytes(adu[0 : length-2])
 	checksum := crc.value()
 
-	adu[length-2] = byte(checksum >> 8)
-	adu[length-1] = byte(checksum)
+	adu[length-1] = byte(checksum >> 8)
+	adu[length-2] = byte(checksum)
 	return
 }
 
@@ -90,7 +90,7 @@ func (mb *rtuPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 	// Calculate checksum
 	var crc crc
 	crc.reset().pushBytes(adu[0 : length-2])
-	checksum := uint16(adu[length-2])<<8 | uint16(adu[length-1])
+	checksum := uint16(adu[length-1])<<8 | uint16(adu[length-2])
 	if checksum != crc.value() {
 		err = fmt.Errorf("modbus: response crc '%v' does not match expected '%v'", checksum, crc.value())
 		return


### PR DESCRIPTION
test for crc.value() is also swapped, maybe a byte slice base interface such as hash.Sum(b []byte) []byte is better to express byte ordering.