### PR TITLE
Add link recovery on EOF for TCP header

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/goburrow/serial"
+	"github.com/grid-x/serial"
 )
 
 const (

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -178,9 +178,11 @@ func (mb *tcpTransporter) Send(aduRequest []byte) (aduResponse []byte, err error
 		if _, err = io.ReadFull(mb.conn, data[:tcpHeaderSize]); err == nil {
 			break
 			// Read attempt failed
-		} else if err != io.EOF || mb.LinkRecoveryTimeout == 0 || time.Now().Sub(recoveryStart) > mb.IdleTimeout {
+		} else if (err != io.EOF && err != io.ErrUnexpectedEOF) ||
+			mb.LinkRecoveryTimeout == 0 || time.Now().Sub(recoveryStart) > mb.IdleTimeout {
 			return
 		}
+		mb.logf("modbus: close connection and retry, because of %v", err)
 
 		mb.close()
 		time.Sleep(mb.LinkRecoveryTimeout)


### PR DESCRIPTION
Solar Edge PV inverters almost always won't respond to the first ACK request, but consecutive requests come through. Therefore, on demand, it 'd be good to retry to establish a new connection and try it again. The headline of this repository say fault-tolerant; therefore, I think this feature comes in handy :smile_cat: 