### PR TITLE
Provide generic logging interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,11 @@ import (
 	"fmt"
 )
 
+// logger is the interface to the required logging functions
+type logger interface {
+	Printf(format string, v ...interface{})
+}
+
 // ClientHandler is the interface that groups the Packager and Transporter methods.
 type ClientHandler interface {
 	Packager

--- a/serial.go
+++ b/serial.go
@@ -6,7 +6,6 @@ package modbus
 
 import (
 	"io"
-	"log"
 	"sync"
 	"time"
 
@@ -24,7 +23,7 @@ type serialPort struct {
 	// Serial port configuration.
 	serial.Config
 
-	Logger      *log.Logger
+	Logger      logger
 	IdleTimeout time.Duration
 
 	mu sync.Mutex

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -135,7 +134,7 @@ type tcpTransporter struct {
 	// Idle timeout to close the connection
 	IdleTimeout time.Duration
 	// Transmission logger
-	Logger *log.Logger
+	Logger logger
 
 	// TCP connection
 	mu           sync.Mutex


### PR DESCRIPTION
This PR removes the dependency on the `log` library and allows other logging implementations like e.g. sirupsen/logrus. See https://github.com/sirupsen/logrus/issues/828 for a detailed discussion.