### PR TITLE
Implement SlaveId and Connector APIs

### DIFF
--- a/asciiclient.go
+++ b/asciiclient.go
@@ -46,6 +46,11 @@ type asciiPackager struct {
 	SlaveId byte
 }
 
+// SetSlave sets modbus slave id for the next client operations
+func (mb *asciiPackager) SetSlave(slaveId byte) {
+	mb.SlaveId = slaveId
+}
+
 // Encode encodes PDU in a ASCII frame:
 //  Start           : 1 char
 //  Address         : 2 chars

--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 type ClientHandler interface {
 	Packager
 	Transporter
+	Connector
 }
 
 type client struct {

--- a/modbus.go
+++ b/modbus.go
@@ -92,3 +92,8 @@ type Packager interface {
 type Transporter interface {
 	Send(aduRequest []byte) (aduResponse []byte, err error)
 }
+
+type Connector interface {
+	Connect() error
+	Close() error
+}

--- a/modbus.go
+++ b/modbus.go
@@ -82,6 +82,7 @@ type ProtocolDataUnit struct {
 
 // Packager specifies the communication layer.
 type Packager interface {
+	SetSlave(slaveId byte)
 	Encode(pdu *ProtocolDataUnit) (adu []byte, err error)
 	Decode(adu []byte) (pdu *ProtocolDataUnit, err error)
 	Verify(aduRequest []byte, aduResponse []byte) (err error)

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -44,6 +44,11 @@ type rtuPackager struct {
 	SlaveId byte
 }
 
+// SetSlave sets modbus slave id for the next client operations
+func (mb *rtuPackager) SetSlave(slaveId byte) {
+	mb.SlaveId = slaveId
+}
+
 // Encode encodes PDU in a RTU frame:
 //  Slave Address   : 1 byte
 //  Function        : 1 byte

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -120,7 +120,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	mb.serialPort.startCloseTimer()
 
 	// Send the request
-	mb.serialPort.logf("modbus: sending %q\n", aduRequest)
+	mb.serialPort.logf("modbus: sending % x\n", aduRequest)
 	if _, err = mb.port.Write(aduRequest); err != nil {
 		return
 	}

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -55,6 +55,11 @@ type tcpPackager struct {
 	SlaveId byte
 }
 
+// SetSlave sets modbus slave id for the next client operations
+func (mb *tcpPackager) SetSlave(slaveId byte) {
+	mb.SlaveId = slaveId
+}
+
 // Encode adds modbus application protocol header:
 //  Transaction identifier: 2 bytes
 //  Protocol identifier: 2 bytes


### PR DESCRIPTION
Intention of this PR is to remove the need for ducktyping like this:

    if handler, ok := q.handler.(*modbus.RTUClientHandler); ok {
        handler.SlaveId = deviceid
    } else if handler, ok := q.handler.(*modbus.TCPClientHandler); ok {
        handler.SlaveId = deviceid
    }

Same goes for the `Connect` and `Close` methods which are already implemented but not exposed via interface.

Replaces https://github.com/goburrow/modbus/pull/22