### PR TITLE
Added a receive flush timeout just prior to launching the next poll when

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 go modbus [![Build Status](https://travis-ci.org/goburrow/modbus.svg?branch=master)](https://travis-ci.org/goburrow/modbus) [![GoDoc](https://godoc.org/github.com/goburrow/modbus?status.svg)](https://godoc.org/github.com/goburrow/modbus)
 =========
-Fault-tolerant, fail-fast implementation of Modbus protocol in Go.
+This is a fork of https://github.com/gburrow/modbus (possibly abandoned),
+a Fault-tolerant, fail-fast implementation of Modbus protocol in Go.
+
+Bug fixes
+-------------------
+* Add a read buffer flush for tcp clients just prior to launching the next call.  This
+  resolves transaction ID mismatches that cause the connection to never work
+  again.
 
 Supported functions
 -------------------


### PR DESCRIPTION
using a TCP connection.  Without this, a slow response can cause
transaction ID mismatches for the life of this TCP connection (it
never recovers).  This occurs when a remote device does answer, but
it answers too slowly.  The request has already timed out, and when
the next request is launched the previous response is read (rather
than the new one) causing this error.