### PR TITLE
Preliminary support for Device Identity modbus function

### DIFF
--- a/api.go
+++ b/api.go
@@ -46,4 +46,7 @@ type Client interface {
 	//ReadFIFOQueue reads the contents of a First-In-First-Out (FIFO) queue
 	// of register in a remote device and returns FIFO value register.
 	ReadFIFOQueue(address uint16) (results []byte, err error)
+
+	// Device Identification
+	ReadIndividualDeviceIdentification(objectID uint8) (results []byte, err error)
 }

--- a/modbus.go
+++ b/modbus.go
@@ -26,6 +26,9 @@ const (
 	FuncCodeReadWriteMultipleRegisters = 23
 	FuncCodeMaskWriteRegister          = 22
 	FuncCodeReadFIFOQueue              = 24
+
+	// Device identification
+	FuncCodeDeviceIdentification       = 43
 )
 
 const (


### PR DESCRIPTION
I hacked away the other night to see if I could read up some useful device information from my Nibe S325 heat pump but was unlucky and it returned 'illegal function' so I have not verified a successful read. I leave it for now but perhaps someone has a device and can verify (and fix) it of needed.  I also feel it lacks a level of abstraction and should probably refine the result into an array of strings, directly or through a helper function, or similar.

I do read registers from the heat pump and for that the modbus module works nicelly, thx a lot!   