### PR TITLE
extend Transporter interface

### DIFF
--- a/modbus.go
+++ b/modbus.go
@@ -90,4 +90,6 @@ type Packager interface {
 // Transporter specifies the transport layer.
 type Transporter interface {
 	Send(aduRequest []byte) (aduResponse []byte, err error)
+	Connect() error
+	Close() error
 }


### PR DESCRIPTION
add Connect() and Close() to the Transporter interface,
so that it is possible to connect if the ClientHandler
variable is an interface