### PR TITLE
Add TCPHandlerFromConnection

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -41,6 +41,16 @@ func NewTCPClientHandler(address string) *TCPClientHandler {
 	return h
 }
 
+// TCPHandlerFromConnection creates a TCP handler from an existing connection.
+func TCPHandlerFromConnection(conn net.Conn) *TCPClientHandler {
+	return &TCPClientHandler{
+		conn:        conn,
+		Address:     conn.RemoteAddr().String(),
+		Timeout:     tcpTimeout,
+		IdleTimeout: tcpIdleTimeout,
+	}
+}
+
 // TCPClient creates TCP client with default handler and given connect string.
 func TCPClient(address string) Client {
 	handler := NewTCPClientHandler(address)


### PR DESCRIPTION
This PR adds a new func for creating `TCPClientHandler` using an existing `net.Conn`.  Some vendors like to obfuscate a regular connection inside some "encryption", or need some custom connection setup. The provided `net.Conn` can be a custom layer that provides "encryption", or the user can do what needs to be done to prepare the connection first.